### PR TITLE
Patch Protontricks to use UNIX socket for IPC

### DIFF
--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -120,8 +120,8 @@ modules:
     sources:
       - type: git
         url: "https://github.com/Matoking/protontricks.git"
-        tag: "1.9.1"
-        commit: 6b4d1058649f3348c6473ffde95a2c158dce5656
+        #tag: "1.9.1"
+        commit: 7b333c6fd10da0fb1e7f51ed3701ba01361ea593
       - type: patch
         paths:
           # Flathub does not support stock icons. Use a vendored icon from the
@@ -129,6 +129,8 @@ modules:
           - patches/protontricks/replace-stock-icon.patch
           - patches/protontricks/rename-launchable.patch
           - patches/protontricks/amend-description.patch
+          # FIXME: Remove this patch once the D-Bus option works with Flatpak
+          - patches/protontricks/revert-bwrap-launcher-dbus.patch
       - type: file
         path: "icon_scalable.svg"
 

--- a/patches/protontricks/revert-bwrap-launcher-dbus.patch
+++ b/patches/protontricks/revert-bwrap-launcher-dbus.patch
@@ -1,0 +1,103 @@
+From b78f098793c38308529bb9c641a1284ffffa1889 Mon Sep 17 00:00:00 2001
+From: Janne Pulkkinen <janne.pulkkinen@protonmail.com>
+Date: Sat, 3 Sep 2022 12:52:37 +0300
+Subject: [PATCH] Revert "Launch bwrap launcher using D-Bus instead of sock"
+
+This is required for the Flatpak version of Protontricks, which does not
+work without granting full access to D-Bus session bus with the new
+implementation. Namely, without full access the `ProcessExited` signal
+is not emitted for some reason, causing any Wine process to hang when
+bwrap is in use.
+
+Revert to the earlier deprecated `--socket` option. This allows bwrap to
+work with the Flatpak version of Protontricks.
+
+Refs #164
+
+This reverts commit 7b333c6fd10da0fb1e7f51ed3701ba01361ea593.
+---
+ CHANGELOG.md                                    |  3 ---
+ src/protontricks/data/scripts/bwrap_launcher.sh |  2 +-
+ src/protontricks/data/scripts/wine_launch.sh    | 13 ++++---------
+ src/protontricks/util.py                        |  2 --
+ 4 files changed, 5 insertions(+), 15 deletions(-)
+
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index a2a2a58..8702b2b 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -13,9 +13,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+ ### Added
+  - Print a warning when multiple Steam directories are detected and `STEAM_DIR` is not used to specify the directory
+  
+-### Changed
+- - Launch Steam Runtime sandbox with `--bus-name` parameter instead of the now deprecated `--socket`
+-
+ ### Fixed
+  - Fix various crashes due to Wine processes under Steam Runtime sandbox using the incorrect working directory
+ 
+diff --git a/src/protontricks/data/scripts/bwrap_launcher.sh b/src/protontricks/data/scripts/bwrap_launcher.sh
+index b5552e1..c2abdb5 100644
+--- a/src/protontricks/data/scripts/bwrap_launcher.sh
++++ b/src/protontricks/data/scripts/bwrap_launcher.sh
+@@ -82,4 +82,4 @@ log_info "Using temporary directory: $PROTONTRICKS_TEMP_PATH"
+ 
+ exec "$STEAM_RUNTIME_PATH"/run --share-pid --launcher \
+ "${mount_params[@]}" -- \
+---bus-name="com.github.Matoking.protontricks.App${STEAM_APPID}_${PROTONTRICKS_SESSION_ID}"
++--socket="$PROTONTRICKS_TEMP_PATH/launcher.sock"
+diff --git a/src/protontricks/data/scripts/wine_launch.sh b/src/protontricks/data/scripts/wine_launch.sh
+index 1f8a432..faf11da 100644
+--- a/src/protontricks/data/scripts/wine_launch.sh
++++ b/src/protontricks/data/scripts/wine_launch.sh
+@@ -168,15 +168,10 @@ elif [[ "$PROTONTRICKS_STEAM_RUNTIME" = "bwrap" ]]; then
+ 
+     log_info "Starting Wine process using 'pressure-vessel-launch'"
+ 
+-    # It would be nicer to use the PID here, but that would break multiple
+-    # simultaneous Protontricks sessions inside Flatpak, which doesn't seem to
+-    # expose the unique host PID.
+-    bus_name="com.github.Matoking.protontricks.App${STEAM_APPID}_${PROTONTRICKS_SESSION_ID}"
+-
+     # Wait until socket is created
+-    if ! dbus-send --print-reply --dest=org.freedesktop.DBus  /org/freedesktop/DBus org.freedesktop.DBus.ListNames | grep -q "$bus_name"; then
+-        log_info "bwrap-launcher D-Bus object not yet available, waiting..."
+-        while ! dbus-send --print-reply --dest=org.freedesktop.DBus  /org/freedesktop/DBus org.freedesktop.DBus.ListNames | grep -q "$bus_name"; do
++    if [[ ! -S "$PROTONTRICKS_TEMP_PATH/launcher.sock" ]]; then
++        log_info "bwrap-launcher socket not yet available, waiting..."
++        while [[ ! -S "$PROTONTRICKS_TEMP_PATH/launcher.sock" ]]; do
+             sleep 0.25
+         done
+     fi
+@@ -197,7 +192,7 @@ elif [[ "$PROTONTRICKS_STEAM_RUNTIME" = "bwrap" ]]; then
+     done
+ 
+     exec "$STEAM_RUNTIME_LAUNCH_SCRIPT" \
+-    --share-pids --bus-name="$bus_name" \
++    --share-pids --socket="$PROTONTRICKS_TEMP_PATH/launcher.sock" \
+     --directory "$PWD" \
+     --env=PROTONTRICKS_INSIDE_STEAM_RUNTIME=1 \
+     "${env_params[@]}" -- "$PROTONTRICKS_PROXY_SCRIPT_PATH" "$@"
+diff --git a/src/protontricks/util.py b/src/protontricks/util.py
+index 5c4772d..cdbd426 100644
+--- a/src/protontricks/util.py
++++ b/src/protontricks/util.py
+@@ -292,7 +292,6 @@ def run_command(
+     wine_environ["PROTON_DIST_PATH"] = str(proton_app.proton_dist_path)
+ 
+     wine_environ["STEAM_APP_PATH"] = str(steam_app.install_path)
+-    wine_environ["STEAM_APPID"] = str(steam_app.appid)
+ 
+     # Unset WINEARCH, which might be set for another Wine installation
+     wine_environ.pop("WINEARCH", "")
+@@ -378,7 +377,6 @@ def run_command(
+ 
+     temp_dir = Path(tempfile.mkdtemp(prefix="protontricks-"))
+     wine_environ["PROTONTRICKS_TEMP_PATH"] = str(temp_dir)
+-    wine_environ["PROTONTRICKS_SESSION_ID"] = temp_dir.name.split("-")[1]
+ 
+     if start_wineserver:
+         wine_environ["PROTONTRICKS_BACKGROUND_WINESERVER"] = "1"
+-- 
+2.35.3
+


### PR DESCRIPTION
Using D-Bus for inter-process communication with Steam Runtime does not
appear to work in Flatpak sandbox for some reason unless full access to
D-Bus session bus is granted. Since this is a very bad idea in terms of
security, revert to the older deprecated UNIX socket method for the time
being to get bwrap working again.

The patch is also built on top of the branch containing the race
condition fix for convenience's sake to better help test that both
issues are fixed properly.

Refs Matoking/protontricks#164