### PR TITLE
Draft: Patch Winetricks to silence "64-bit prefix" popup

### DIFF
--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -163,6 +163,11 @@ modules:
           - type: archive
             url: "https://github.com/Winetricks/winetricks/archive/20220411.tar.gz"
             sha256: c16e09ee4e5fda48a49ae9515a9c6d175713792be1b85ea92624d93e37effbd0
+          - type: patch
+            paths:
+              - patches/winetricks/disable-64bit-warning.patch
+              - patches/winetricks/update-version.patch
+
         modules:
 
           - name: p7zip

--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -301,5 +301,4 @@ modules:
       - install -Dm644 ld.so.conf /app/etc/ld.so.conf
     sources:
       - type: file
-        dest-filename: ld.so.conf
-        url: data:/app/lib32%0A/app/lib/i386-linux-gnu%0A
+        path: ld.so.conf

--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,0 +1,2 @@
+/app/lib32
+/app/lib/i386-linux-gnu

--- a/patches/winetricks/disable-64bit-warning.patch
+++ b/patches/winetricks/disable-64bit-warning.patch
@@ -1,0 +1,36 @@
+From d902d31fd48ed1b9cb4bad1b2cc8cb159cd4985d Mon Sep 17 00:00:00 2001
+From: Janne Pulkkinen <janne.pulkkinen@protonmail.com>
+Date: Wed, 23 Nov 2022 19:23:17 +0200
+Subject: [PATCH 1/2] Disable "64-bit prefix" warning popup
+
+The 64-bit prefix is used with every prefix on Proton, so there is no
+need to show the popup every time.
+---
+ src/winetricks | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/winetricks b/src/winetricks
+index c0c3ff9..76a7007 100755
+--- a/src/winetricks
++++ b/src/winetricks
+@@ -5313,11 +5313,17 @@ winetricks_set_wineprefix()
+         W_COMMONFILES="$(w_pathconv -u "${W_COMMONFILES_WIN}")"
+ 
+         # 64-bit prefixes still have plenty of issues:
++        # Protontricks patch: Don't display a warning popup for the 64-bit
++        # prefix
++        _winetricks_gui="${WINETRICKS_GUI}"
++        WINETRICKS_GUI=none
+         case ${LANG} in
+             ru*) w_warn "Вы используете 64-битный WINEPREFIX. Важно: многие ветки устанавливают только 32-битные версии пакетов. Если у вас возникли проблемы, пожалуйста, проверьте еще раз на чистом 32-битном WINEPREFIX до отправки отчета об ошибке." ;;
+             pt*) w_warn "Você está usando um WINEPREFIX de 64-bit. Observe que muitos casos instalam apenas versões de pacotes de 32-bit. Se você encontrar problemas, teste novamente em um WINEPREFIX limpo de 32-bit antes de relatar um bug." ;;
+             *) w_warn "You are using a 64-bit WINEPREFIX. Note that many verbs only install 32-bit versions of packages. If you encounter problems, please retest in a clean 32-bit WINEPREFIX before reporting a bug." ;;
+         esac
++        WINETRICKS_GUI="${_winetricks_gui}"
++
+     else
+         WINE64="false"
+         WINE_ARCH="${WINE}"
+-- 
+2.38.1
+

--- a/patches/winetricks/update-version.patch
+++ b/patches/winetricks/update-version.patch
@@ -1,0 +1,28 @@
+From 837afc4f8a4aee7e71370d9daa51bc62b04d12f7 Mon Sep 17 00:00:00 2001
+From: Janne Pulkkinen <janne.pulkkinen@protonmail.com>
+Date: Wed, 23 Nov 2022 19:25:58 +0200
+Subject: [PATCH 2/2] Add "protontricks" marker to version output
+
+The version of Winetricks shipped with Protontricks Flatpak is patched,
+so mark it accordingly to make it clear to any Winetricks maintainers
+receiving bug reports.
+---
+ src/winetricks | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/winetricks b/src/winetricks
+index 5ad8b2f..bb1e9db 100755
+--- a/src/winetricks
++++ b/src/winetricks
+@@ -3234,7 +3234,7 @@ winetricks_print_version()
+     winetricks_get_sha256sum_prog
+ 
+     w_get_sha256sum "$0"
+-    echo "${WINETRICKS_VERSION} - sha256sum: ${_W_gotsha256sum}"
++    echo "${WINETRICKS_VERSION} (protontricks-flatpak) - sha256sum: ${_W_gotsha256sum}"
+ }
+ 
+ # Run a small wine command for internal use
+-- 
+2.38.1
+


### PR DESCRIPTION
The "64-bit prefix" warning popup is shown for every Proton app. Patch Winetricks to only print it, as it's a common source of confusion for users.

Also patch the version output for Winetricks as we want to make it evident that the Winetricks installation is patched.