### PR TITLE
Update Winetricks

### DIFF
--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -165,7 +165,7 @@ modules:
           - type: git
             url: "https://github.com/Matoking/winetricks.git"
             branch: snapshot-2023-08-16-pt
-            commit: fea92b1f9af42853567cbd042cd80e192579b2b4
+            commit: 67a39b472edeaefb1b06ba54538a6460aa3cbb49
 
         modules:
 


### PR DESCRIPTION
Update Winetricks to disable the update check. Winetricks cannot be updated inside the Flatpak sandbox.