### PR TITLE
add permission to sd-card dir for steam deck

### DIFF
--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -60,6 +60,7 @@ finish-args:
   - --filesystem=xdg-music
   - --filesystem=xdg-videos
   - --filesystem=xdg-download
+  - --filesystem=/run/media/deck
 
 add-extensions:
   org.freedesktop.Platform.Compat.i386:


### PR DESCRIPTION
Right now when you launch protontricks on steam deck and install games on a sd-card it needs permissions for this directory
/run/media/deck/UUID-of-sd-card

Protontricks gives the correct flatpak override command however when you use multiple sd-cards and swap them out on a regular basis to play different games the uuid will change and you'd have to do a slightly different flatpak override command for every sd- card you plug in.

This will of course also remove that first initial step of pasting the flatpak override command and it is easier to get started for steam deck users.