### PR TITLE
Add mount paths to secondary drives

### DIFF
--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -62,6 +62,10 @@ finish-args:
   - --filesystem=xdg-videos
   - --filesystem=xdg-download
 
+  # Secondary drives
+  - --filesystem=/run/media
+  - --filesystem=/mnt
+
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu


### PR DESCRIPTION
`/run/media/...` and `/mnt/...` are common mount paths for secondary drives where people may install their games. For example, a Steam Deck mounts an SD card at `/run/media/deck/<UDID>`. Desktop installations may use `/mnt` for permanently mounted drives as well.

Adding these permissions out the gate would mitigate the initial prompt about not having sufficient permissions to access folders.