### PR TITLE
Add setuptools-scm back

### DIFF
--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -102,6 +102,7 @@ cleanup:
 modules:
 
   - python3-Pillow.json
+  - python3-setuptools-scm.json
   - vdf.json
 
   - name: protontricks

--- a/python3-setuptools-scm.json
+++ b/python3-setuptools-scm.json
@@ -1,0 +1,19 @@
+{
+    "name": "python3-setuptools-scm",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"setuptools-scm\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl",
+            "sha256": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/a0/b9/1906bfeb30f2fc13bb39bf7ddb8749784c05faadbd18a21cf141ba37bff2/setuptools_scm-8.1.0-py3-none-any.whl",
+            "sha256": "897a3226a6fd4a6eb2f068745e49733261a21f70b1bb28fce0339feb978d9af3"
+        }
+    ]
+}


### PR DESCRIPTION
The library isn't actually included with the Freedesktop SDK 24.08 for some reason. The Python package build will succeed but no version number is included, which will cause problems with any scripts that expect to parse the version number from command-line output.