### PR TITLE
Update Winetricks fork

### DIFF
--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -170,7 +170,7 @@ modules:
         sources:
           - type: git
             url: https://github.com/Matoking/winetricks.git
-            commit: fdd84f9ba3e36b5e8d115258ce6e41247523f593  # branch: 20250102-pt
+            commit: 72e26af1552a237790c55db14be84c8d384c87e2  # branch: 20250102-pt
 
         modules:
 


### PR DESCRIPTION
Update Winetricks fork to include the patch to skip "unknown file arch" warnings by reading the `WINE_BIN` and `WINESERVER_BIN` properly.