### PR TITLE
7zip: Fix version pattern

### DIFF
--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -245,7 +245,7 @@ modules:
                 strip-components: 0
                 x-checker-data:
                   type: git
-                  tag-pattern: ^v([\\d.]+)$
+                  tag-pattern: ^([\\d.]+)$
 
           - name: cabextract
             build-options:


### PR DESCRIPTION
7zip doesn't start its tags with a v in its Github repo.