### PR TITLE
Add autoprune-unless to GL32 platform extension

### DIFF
--- a/com.github.Matoking.protontricks.yml
+++ b/com.github.Matoking.protontricks.yml
@@ -83,6 +83,7 @@ add-extensions:
     merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib/dri;lib/d3d;vulkan/explicit_layer.d;vulkan/implicit_layer.d
     download-if: active-gl-driver
     enable-if: active-gl-driver
+    autoprune-unless: active-gl-driver
 
   com.valvesoftware.Steam.CompatibilityTool:
     subdirectories: true


### PR DESCRIPTION
Without this present Flatpak doesn't delete unused GL32 platform extensions.