### PR TITLE
Update to Pillow 12.2.0

### DIFF
--- a/python3-Pillow.json
+++ b/python3-Pillow.json
@@ -7,8 +7,23 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/f3/0d/d0d6dea55cd152ce3d6767bb38a8fc10e33796ba4ba210cbab9354b6d238/pillow-11.3.0.tar.gz",
-            "sha256": "3828ee7586cd0b2091b6209e5ad53e20d0649bbe87164a459d0676e035e8f523",
+            "url": "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+            "sha256": "eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3",
+            "only-arches": [
+                "x86_64"
+            ],
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "pillow"
+            }
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+            "sha256": "5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed",
+            "only-arches": [
+                "aarch64"
+            ],
             "x-checker-data": {
                 "type": "pypi",
                 "name": "pillow"


### PR DESCRIPTION
Update to Pillow 12.2.0. Use binary wheels instead of building from source. Building from source prevents reproducibility due to differences in `.so` files.